### PR TITLE
fixed issue requesting an endpoint with a expired certificate

### DIFF
--- a/src/steps/pickFile.js
+++ b/src/steps/pickFile.js
@@ -17,6 +17,7 @@ async function pickFile (input, state) {
 	try {
 		response = await got(`${state.pkg.name}@${state.version}/flat`, {
 			baseUrl: jsDelivrEndpoint,
+			rejectUnauthorized: false,
 			headers: {
 				'user-agent': userAgent,
 			},


### PR DESCRIPTION
I made a fix. As I mentioned the issue was that the request to the jsDelivr -endpoint would (/could?) fail because of a expired certificate. This should circumvent that.